### PR TITLE
Add xDSL Config Card for Bridge-Mode

### DIFF
--- a/www/lua/cards_limiter.lua
+++ b/www/lua/cards_limiter.lua
@@ -13,6 +13,7 @@ local bridge_limit_list = {
   ["diagnostics.lp"] = true,
   ["iproutes.lp"] = true,
   ["system.lp"] = true,
+  ["xdsl.lp"] = true,
 }
 
 local voice_limit_list = {


### PR DESCRIPTION
Giving users in Bridge-Mode the ability to use the "xDSL Config" card