### PR TITLE
modern SSL profile for nginx

### DIFF
--- a/decompressed/gui_file/etc/nginx/nginx.conf
+++ b/decompressed/gui_file/etc/nginx/nginx.conf
@@ -39,19 +39,23 @@ http {
         # ipv4
         listen       80;
         listen       443 ssl;
-		listen       8443 ssl;
+	listen       8443 ssl;
         # ipv6
         listen       [::]:80;
         listen       [::]:443 ssl;
-		listen       [::]:8443 ssl;
+	listen       [::]:8443 ssl;
 
         ssl_certificate /etc/nginx/server.crt;
         ssl_certificate_key /etc/nginx/server.key;
         # based on https://wiki.mozilla.org/Security/Server_Side_TLS
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:!DSS;
+        ssl_protocols TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         ssl_prefer_server_ciphers on;
-        ssl_session_tickets off;
+        ssl_session_timeout 1d;
+	ssl_session_cache shared:SSL:50m;
+	ssl_session_tickets off;
+	# HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+	add_header Strict-Transport-Security max-age=15768000;
 
         server_name  localhost;
         root /www/docroot;


### PR DESCRIPTION
we don't need TLSv1 or TLSv1.1 anymore...