### PR TITLE
Fix dnsmasq fatal crashes after rooting

### DIFF
--- a/decompressed/base/etc/init.d/rootdevice
+++ b/decompressed/base/etc/init.d/rootdevice
@@ -138,7 +138,8 @@ fix_dns_dhcp_bug() {
 	uci set dhcp.odhcpd.maindhcp="0"
 	if [ $(pgrep "odhcpd") ]; then
 		/etc/init.d/odhcpd stop
-		/etc/init.d/dnsmasq restart
+		killall dnsmasq
+		/etc/init.d/dnsmasq start
 	fi
 	if [ "$(ls /etc/rc.d/ | grep odhcpd)" ]; then
 		/etc/init.d/odhcpd disable
@@ -1215,7 +1216,8 @@ root() {
 	/etc/init.d/power restart
 	
 	logger_command "Restarting dnsmasq"
-	/etc/init.d/dnsmasq restart
+	killall dnsmasq
+	/etc/init.d/dnsmasq start
 	
 	rm /root/.check_process #we remove the placeholder as the process is complete
 	logger_command "Process done."


### PR DESCRIPTION
Log:
<26>Sep 14 15:48:55 dnsmasq[15631]: failed to bind DHCP server socket: Address already in use	10.0.0.138	14/09 13:48:57.623	
<26>Sep 14 15:48:55 dnsmasq[15631]: FAILED to start up	10.0.0.138	14/09 13:48:57.627	
<30>Sep 14 15:48:55 procd: Instance dnsmasq::dnsmasq s in a crash loop 6 crashes, 0 seconds since last crash 10.0.0.138 14/09 13:48:57.632	

Caused by the restarting of dnsmasq. Multiple instances of dnsmasq were trying to run, producing these messages.
Rather than restarting, I have modified the script to kill and start.