### PR TITLE
Revert "Add Abbreviated Device Description to Footer #274"

### DIFF
--- a/decompressed/gui_file/www/docroot/modals/gateway-modal.lp
+++ b/decompressed/gui_file/www/docroot/modals/gateway-modal.lp
@@ -361,8 +361,6 @@ local content = {
   vendor = "uci.env.var.company_name",
   product_name = "uci.env.var.prod_name",
   friendly_product_name = "uci.env.var.prod_friendly_name",
-  variant_friendly_name = "uci.env.var.variant_friendly_name",
-  provisioning_code = "uci.env.var.provisioning_code",
   software_name = "uci.version.version.@version[0].marketing_name",
   software_version = "uci.version.version.@version[0].marketing_version",
   firmware_version = "uci.env.var.friendly_sw_version_activebank",
@@ -388,7 +386,7 @@ if content["friendly_product_name"] and content["friendly_product_name"] == "AGH
 end
 
 if not ( content.friendly_product_name == "" ) then
-	content.product_name = format("%s %s",content.provisioning_code, content.variant_friendly_name)
+	content.product_name = format("%s ( %s )",content.product_name,content.friendly_product_name)
 end
 
 
@@ -789,7 +787,7 @@ ngx.print(ui_helper.createMessages(message_helper.popMessages()))
 
       local html = {}
       html[#html + 1] = ui_helper.createLabel(T"Product Vendor", content["vendor"], basic)
-      html[#html + 1] = ui_helper.createLabel(T"Product", content["product_name"], basic)
+      html[#html + 1] = ui_helper.createLabel(T"Product Name", content["product_name"], basic)
       html[#html + 1] = ui_helper.createLabel(T"Software Version", content["firmware_version"], basic)
 	  html[#html + 1] = ui_helper.createLabel(T"Gui Version", content["gui_version"], basic)
 	  html[#html + 1] = ui_helper.createLabel(T"Hostname", system_data["system_hostname"], advancedshow )

--- a/decompressed/gui_file/www/gateway-snippets/footer.lp
+++ b/decompressed/gui_file/www/gateway-snippets/footer.lp
@@ -10,8 +10,6 @@ local format = string.format
 local cui = {
 	timestamp = "uci.version.version.@version[0].timestamp",
 	gui_version = "uci.env.var.gui_version",
-	variant_friendly_name = "uci.env.var.variant_friendly_name",
-	provisioning_code = "uci.env.var.provisioning_code",
 }
 
 content_helper.getExactContent(cui)
@@ -32,13 +30,11 @@ local html = {}
 html[#html+1] =		'<div id="footer" class="row">'
 html[#html+1] =			'<div class="copyright">'
 html[#html+1] =				format('<p>&copy; Technicolor %s </p>', current_year)
-html[#html+1] =				format('<p>%s %s GUI Version', cui.provisioning_code, cui.variant_friendly_name)
+html[#html+1] =				format('<p>GUI Version [ %s ] 2018 ',cui.gui_version)
 							if session:hasAccess("/modals/changelog.lp") then
-html[#html+1] =					format(' <a href data-toggle="modal" data-remote="modals/changelog.lp">%s</a>', cui.gui_version)
-							else
-html[#html+1] =					format(' %s', cui.gui_version)
+html[#html+1] =					'<a href data-toggle="modal" data-remote="modals/changelog.lp">Changelog</a>'
 							end
-html[#html+1] =				format(' %s </p>', "2018")
+html[#html+1] =				'</p>'
 html[#html+1] =				'<p>Coded & Expanded by <font style="color:#0088cc;">Ansuel </font>and <a href="https://github.com/Ansuel/tch-nginx-gui/graphs/contributors">these GitHub users.</a><br> Unlock Utility by <font style="color:#0088cc;">ADeltaX</font>'
 
 							if not ( tostring(gettext.language()) == "en-us" ) then

--- a/decompressed/gui_file/www/info-cards/001_gateway.lp
+++ b/decompressed/gui_file/www/info-cards/001_gateway.lp
@@ -14,8 +14,6 @@ local find, sub, format = string.find, string.sub, string.format
 local content = {
   product_name = "uci.env.var.prod_name",
   friendly_product_name = "uci.env.var.prod_friendly_name",
-  variant_friendly_name = "uci.env.var.variant_friendly_name",
-  provisioning_code = "uci.env.var.provisioning_code",
   software_name = "uci.version.version.@version[0].marketing_name",
   software_version = "uci.version.version.@version[0].marketing_version",
   firmware_version = "uci.env.var.friendly_sw_version_activebank",
@@ -35,7 +33,7 @@ if content["friendly_product_name"] and content["friendly_product_name"] == "AGH
 end
 
 if not ( content.friendly_product_name == "" ) and not ( content.friendly_product_name == content.product_name ) then
-	content.product_name = format("%s %s",content.provisioning_code, content.variant_friendly_name)
+	content.product_name = format("%s ( %s )",content.product_name,content.friendly_product_name)
 end
 
 local nf_conntrack_count = io.popen("sysctl -n -e net.nf_conntrack_max net.ipv4.netfilter.ip_conntrack_max")
@@ -66,7 +64,7 @@ nf_conntrack_count:close()
 	local html = {}
 	
 	basic.span["data-bind"] = nil
-	html[#html + 1] = ui_helper.createLabel(T"Product", content["product_name"], basic)
+	html[#html + 1] = ui_helper.createLabel(T"Product Name", content["product_name"], basic)
 	html[#html + 1] = ui_helper.createLabel(T"Software Version", format("%s %s",content["software_version"],content["software_name"]), basic)
 	html[#html + 1] = '<div class="control-group">'
 	html[#html + 1] =   '<label class="control-label">' .. T("GUI Version") .. '</label>'


### PR DESCRIPTION
Reverts Ansuel/tch-nginx-gui#281

https://github.com/Ansuel/tch-nginx-gui/issues/274#issuecomment-429249353

>  `cat /etc/config/env`
```
config envvars 'var'
...
	option variant_friendly_name 'TG800vac'
```
No equivalent on TG799 - code needs to be more robust.

`variant_friendly_name = "uci.env.var.variant_friendly_name",` will fail in each file if `variant_friendly_name` does not exist.