### PR TITLE
Update language files

### DIFF
--- a/decompressed/gui_file/www/lang/de-de/webui-core.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-core.po
@@ -847,9 +847,6 @@ msgstr "Diagnose DSL"
 msgid "Diagnostics Ping&Trace"
 msgstr "Diagnose Ping&Trace"
 
-msgid "Port Mirror"
-msgstr "Port-Spiegelung"
-
 msgid "Diagnostics Port Mirror"
 msgstr "Diagnose Port-Spiegelung"
 
@@ -1689,9 +1686,6 @@ msgstr "NA"
 
 msgid "NAT Helpers (ALG's)"
 msgstr "NAT Helfer (ALGs)"
-
-msgid "NAT Helpers"
-msgstr "NAT Helfer"
 
 msgid "NAT-PMP Enabled"
 msgstr "NAT-PMP eingeschaltet"
@@ -3226,6 +3220,11 @@ msgstr "1. Die maximal empfohlene Packet-Anzahl ist dynamisch (verwendet die Hä
 msgid "DSLAM Firmware"
 msgstr "DSLAM Firmware"
 
+msgid "<strong %s>%d Wireless Control</strong> rule defined"
+msgid_plural "<strong %s>%d Wireless Control</strong> rules defined"
+msgstr[0] "<strong %s>%d Wireless Steuerungs</strong> Regel definiert"
+msgstr[1] "<strong %s>%d Wireless Steuerungs</strong> Regeln definiert"
+
 msgid "WanSensing sets the connection mode automatically. Disable this to set the connection mode manually. After saving the changes the connection options will be shown."
 msgstr "WanSensing setzt den Verbindungsmodus automatisch. Deaktivieren Sie dies, wenn Sie den Verbindungsmodus manuell wählen wollen. Nachdem die Einstellung gespeichert wurde, werden die möglichen Modi angezeigt."
 
@@ -3257,12 +3256,13 @@ msgid "GUI Settings & Utility"
 msgstr "GUI Einstellungen & Hilfsfunktionen"
 
 msgid "Check this to remove config after firmware update.<br/>This won't remove root.<br/>It is advertised to check this if you are downgrading the firmware."
-msgstr "Kreuzen Sie dies an, um die Konfiguration nach der Firmware-Aktualisierung  zu entfernen. Dies wird root erhalten. Dies dient dazu, die Firmware auf eine niedrigere Version zu aktualisieren"
-
-msgid "<strong %s>%d Wireless Control</strong> rule defined"
-msgid_plural "<strong %s>%d Wireless Control</strong> rules defined"
-msgstr[0] "<strong %s>%d Wireless Steuerungs</strong> Regel definiert"
-msgstr[1] "<strong %s>%d Wireless Steuerungs</strong> Regeln definiert"
+msgstr "Kreuzen Sie dies an, um die Konfiguration nach der Firmware-Aktualisierung zu entfernen.<br/>Dies wird root erhalten.<br/>Dies dient dazu, die Firmware auf eine niedrigere Version zu aktualisieren."
 
 msgid "Remove config file with upgrade"
 msgstr ""
+
+msgid "Port Mirror"
+msgstr "Port-Spiegelung"
+
+msgid "NAT Helpers"
+msgstr "NAT Helfer"

--- a/decompressed/gui_file/www/lang/de-de/webui-printersharing.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-printersharing.po
@@ -18,8 +18,8 @@ msgstr ""
 msgid "SMB/CIFS is disabled"
 msgstr "SMB/CIFS ist deaktiviert"
 
-msgid "To connect: \\%s\\ or \\%s\\ "
-msgstr "Zum Verbinden: \\%s\\ oder \\%s\\ "
+msgid "To connect: \\%s\ or \\%s\ "
+msgstr "Zum Verbinden: \\%s\ oder \\%s\ "
 
 msgid "Enabled"
 msgstr "Aktiviert"

--- a/decompressed/gui_file/www/lang/it-it/webui-core.po
+++ b/decompressed/gui_file/www/lang/it-it/webui-core.po
@@ -3256,7 +3256,13 @@ msgid "GUI Settings & Utility"
 msgstr "Opzioni e utility GUI"
 
 msgid "Check this to remove config after firmware update.<br/>This won't remove root.<br/>It is advertised to check this if you are downgrading the firmware."
-msgstr "Selezionando questa opzione verrà rimosso la configurazione dopo l'aggiornamento firmware.<br/>Questo non rimuoverà il root.<br/>Seleziona questa opzione nel caso di downgrade del firmware."
+msgstr "Selezionando questa opzione verrà azzerata la configurazione dopo l'aggiornamento firmware.<br/>Questo non rimuoverà il root.<br/>Seleziona questa opzione nel caso di downgrade del firmware."
 
 msgid "Remove config file with upgrade"
-msgstr "Rimuovi configurazione con l'aggiornamento"
+msgstr "Rimuovi file configurazione dopo l'aggiornamento"
+
+msgid "Port Mirror"
+msgstr "Mirror porte"
+
+msgid "NAT Helpers"
+msgstr "Helper NAT"


### PR DESCRIPTION
Revised Italian language with new strings (found by de translator)
"Port Mirror"
"NAT Helpers"

Added a new string "Remove config file with upgrade"

Revised long string adding <br/> and end punctation.

"Check this to remove config after firmware update.<br/>This won't remove root.<br/>It is advertised to check this if you are downgrading the firmware."

Aligned de language file (2 string to translate in webui-core.po)

"Radius Accounting Server secret"
"Remove config file with upgrade"

Correct in de/webui-printersharing.po

msgid "To connect: \\%s\ or \\%s\ "
msgstr "Zum Verbinden: \\%s\ oder \\%s\ "

with a single \ after %s.