### PR TITLE
Add prevent_total_brick commands to rootdevice

### DIFF
--- a/decompressed/base/etc/init.d/rootdevice
+++ b/decompressed/base/etc/init.d/rootdevice
@@ -1732,6 +1732,12 @@ start_stop_nginx() {
 		nginx_count=$((nginx_count+1))
 	done
 }
+prevent_total_brick() {
+	#Stop reboot on coredump to prevent bootloops
+	uci set system.@coredump[0].reboot='0'
+	#Enable hardware serial console to intercept bootloops
+	sed 's/#//' /etc/inittab
+}
 
 root() {
 
@@ -1861,6 +1867,7 @@ root() {
 	disable_upload_coredump_and_reboot
 	logger_command "Restoring nginx additional option if needed..."
 	restore_nginx
+	prevent_total_brick
 
 	rootchecks #This check root availability
 

--- a/decompressed/base/etc/init.d/rootdevice
+++ b/decompressed/base/etc/init.d/rootdevice
@@ -1733,8 +1733,6 @@ start_stop_nginx() {
 	done
 }
 prevent_total_brick() {
-	#Stop reboot on coredump to prevent bootloops
-	uci set system.@coredump[0].reboot='0'
 	#Enable hardware serial console to intercept bootloops
 	sed 's/#//' /etc/inittab
 }


### PR DESCRIPTION
Have added the function: 
```prevent_total_brick() {
	#Stop reboot on coredump to prevent bootloops
	uci set system.@coredump[0].reboot='0'
	#Enable hardware serial console to intercept bootloops
	sed 's/#//' /etc/inittab
}
```

To prevent incompatible devices/irresponsible people installing incompatible packages from totally bricking their modem.
Based on: 
https://whrl.pl/RfjGal
https://whrl.pl/RfjGVG