### PR TITLE
Added translations and made bridge mode status translatable

### DIFF
--- a/decompressed/gui_file/www/cards/snippets/002_broadband_bridge.lp
+++ b/decompressed/gui_file/www/cards/snippets/002_broadband_bridge.lp
@@ -28,10 +28,10 @@ end
 
 -- Figure out interface state
 local intf_state_map = {
-    disabled = T"Bridge "..wan_bridge.. " disabled",
-    connected = T"Bridge "..wan_bridge.. " connected",
-    disconnected = T"Bridge "..wan_bridge.. " not connected",
-	connecting = T"Connecting "..wan_bridge.. " ...",
+    disabled = T"Bridge disabled",
+    connected = T"Bridge connected",
+    disconnected = T"Bridge not connected",
+	connecting = T"Connecting...",
 }
 
 local intf_light_map = {

--- a/decompressed/gui_file/www/lang/de-de/webui-core.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-core.po
@@ -3406,10 +3406,10 @@ msgid "LuCI GUI"
 msgstr "LuCI GUI"
 
 msgid "Skip Spoof Version Check"
-msgstr ""
+msgstr "Überpringe Spoof Versionüberprüfung"
 
 msgid "Disable override of Version Spoof at every GUI update. This is also usefull to permit cwmp to autoupdate the modem"
-msgstr ""
+msgstr "Abschalten des Spoof der Version bei der GUI AKtualisierung. Das ist nützlich, um cwmp die automatische Aktualisierung des Modems zu erlauben."
 
 msgid "Spoof Version Mode"
 msgstr ""

--- a/decompressed/gui_file/www/lang/de-de/webui-core.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-core.po
@@ -3413,3 +3413,15 @@ msgstr "Abschalten des Spoof der Version bei der GUI AKtualisierung. Das ist nü
 
 msgid "Spoof Version Mode"
 msgstr "Spoof Versionsmodus"
+
+msgid "Bridge connected"
+msgstr "Brücke verbunden"
+
+msgid "Bridge not connected"
+msgstr "Brücke nicht verbunden"
+
+msgid "Bridge disabled"
+msgstr "Brücke deaktiviert"
+
+msgid "Connecting..."
+msgstr "Verbinde..."

--- a/decompressed/gui_file/www/lang/de-de/webui-core.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-core.po
@@ -3412,4 +3412,4 @@ msgid "Disable override of Version Spoof at every GUI update. This is also usefu
 msgstr "Abschalten des Spoof der Version bei der GUI AKtualisierung. Das ist nützlich, um cwmp die automatische Aktualisierung des Modems zu erlauben."
 
 msgid "Spoof Version Mode"
-msgstr ""
+msgstr "Spoof Versionsmodus"

--- a/decompressed/gui_file/www/lang/de-de/webui-qos.po
+++ b/decompressed/gui_file/www/lang/de-de/webui-qos.po
@@ -125,4 +125,4 @@ msgid "Yes"
 msgstr "Ja"
 
 msgid "Qos Wireless Status"
-msgstr ""
+msgstr "QoS Drahtlos Status"

--- a/decompressed/gui_file/www/lang/it-it/webui-core.po
+++ b/decompressed/gui_file/www/lang/it-it/webui-core.po
@@ -3425,3 +3425,15 @@ msgstr "Comunica a cwmp l'ultima versione stabile impostata dallo script root"
 
 msgid "Set the version to comunicate to cwmp manually"
 msgstr "Imposta manualmente la versione da comunicare a cwmp"
+
+msgid "Bridge connected"
+msgstr ""
+
+msgid "Bridge not connected"
+msgstr ""
+
+msgid "Bridge disabled"
+msgstr ""
+
+msgid "Connecting..."
+msgstr ""


### PR DESCRIPTION
I modified the broadband status page to be translatable.

Alas, I found no easy way of keeing the bridge interface name in the string, however, it is not needed, since the user cannot do anything with that information.

@bovirus : I added empty strings in the italian translations.