### PR TITLE
Update StateMachines.lua (blue led)

### DIFF
--- a/decompressed/ledfw_support-specificDGA/etc/ledfw/stateMachines.lua
+++ b/decompressed/ledfw_support-specificDGA/etc/ledfw/stateMachines.lua
@@ -133,8 +133,8 @@ stateMachines = {
             power_started = {
                 staticLed("power:orange", false),
                 staticLed("power:red", false),
-                staticLed("power:blue", false),
-                staticLed("power:green", true)
+                staticLed("power:blue", true),
+                staticLed("power:green", false)
             },
             service_ok_eco = {
                 staticLed("power:orange", false),


### PR DESCRIPTION
Change status led for only POWER (not service started yet) from Green to Blue
When the modem is switched ON the Info Led is Blue.
When the modem is switched ON and the service started the Info Led will be Green.