### PR TITLE
Make Nginx ssl only

### DIFF
--- a/decompressed/gui_file/etc/nginx/nginx.conf
+++ b/decompressed/gui_file/etc/nginx/nginx.conf
@@ -37,10 +37,10 @@ http {
 
     server {
         # ipv4
-        listen       80;
+        listen       443 ssl;
 		listen       8443 ssl;
         # ipv6
-        listen       [::]:80;
+        listen       [::]:443 ssl;
 		listen       [::]:8443 ssl;
 
     ssl_certificate /etc/nginx/server.crt;

--- a/decompressed/gui_file/etc/nginx/nginx.conf
+++ b/decompressed/gui_file/etc/nginx/nginx.conf
@@ -38,11 +38,9 @@ http {
     server {
         # ipv4
         listen       80;
-        listen       443 ssl;
 		listen       8443 ssl;
         # ipv6
         listen       [::]:80;
-        listen       [::]:443 ssl;
 		listen       [::]:8443 ssl;
 
     ssl_certificate /etc/nginx/server.crt;


### PR DESCRIPTION
Removed Nginx access by http and only allow ssl connections by default.
Edit: Fixed the mistake because I figured out that you still can modify the file in files changed on github in the pr.