### PR TITLE
Gui: Display Used memory instead of Free RAM memory

### DIFF
--- a/decompressed/gui_file/www/docroot/ajax/cpuload.lua
+++ b/decompressed/gui_file/www/docroot/ajax/cpuload.lua
@@ -4,12 +4,12 @@ local readfile = require("web.content_helper").readfile
 local post_helper = require("web.post_helper")
 local ngx = ngx
 
-local ram = tonumber(proxy.get("sys.mem.RAMFree")[1].value or 0) or 0
+local ram = tonumber(proxy.get("sys.mem.RAMUsed")[1].value or 0) or 0
 local cpu_usage = proxy.get("sys.proc.CPUUsage")[1].value or "0"
 
 local data = {
 	cpuusage = cpu_usage .. "%" or "0",
-	ram_free = math.floor(ram / 1024),
+	ram_used = math.floor(ram / 1024),
 	uptime = post_helper.secondsToTime(readfile("/proc/uptime","number",floor)),
 	connection = readfile("/proc/sys/net/netfilter/nf_conntrack_count"),
 	system_time = os.date("%d/%m/%Y %Hh:%Mm:%Ss",os.time()),

--- a/decompressed/gui_file/www/info-cards/001_gateway.lp
+++ b/decompressed/gui_file/www/info-cards/001_gateway.lp
@@ -19,14 +19,14 @@ local content = {
   firmware_version = "uci.env.var.friendly_sw_version_activebank",
   gui_version = "rpc.system.modgui.gui_version",
   cpuusage = "sys.proc.CPUUsage",
-  ram_free = "sys.mem.RAMFree",
+  ram_used = "sys.mem.RAMUsed",
   ram_total = "sys.mem.RAMTotal",
   outdated_ver = "uci.modgui.gui.outdated_ver",
 }
 
 content_helper.getExactContent(content)
 
-content["ram_free"] = math.floor(tonumber(content["ram_free"]) / 1024) 
+content["ram_used"] = math.floor(tonumber(content["ram_used"]) / 1024) 
 content["ram_total"] = math.floor(tonumber(content["ram_total"]) / 1024) 
 
 if content.outdated_ver == "1" then
@@ -97,10 +97,10 @@ nf_conntrack_count:close()
 	basic.span["data-bind"] = "text: cpuusage"
 	html[#html + 1] = ui_helper.createLabel(T"CPU Usage", content["cpuusage"] .. "%", basic)
 	html[#html + 1] = '<div class="control-group">'
-	html[#html + 1] =   '<label class="control-label">' .. T("Free Memory") .. '</label>'
+	html[#html + 1] =   '<label class="control-label">' .. T("RAM Usage") .. '</label>'
 	html[#html + 1] =   '<div class="controls">'
 	html[#html + 1] =     '<span id="Ram" class=" simple-desc span3">'
-	html[#html + 1] =		format('<span data-bind="text: ram_free">%s</span>',content["ram_free"])
+	html[#html + 1] =		format('<span data-bind="text: ram_used">%s</span>',content["ram_used"])
 	html[#html + 1] =		format(' / %s MB', content["ram_total"])
 	html[#html + 1] =	  '</span>'
 	html[#html + 1] =   '</div>'


### PR DESCRIPTION
Viewing the free memory is useless as that's simply unused portion of memory and it can easily drop under 10MB freaking the user.
Total-Used=Available , which includes free memory but also includes stuff like Buffered/Cached memory which is dynamically managed to fit the bill.

I opted for showing Used / Total to respect the logic of the surrounding elements: numbers grow as resources consumption grows, but one can prefer Available / Total which is simply subtracting the two as I mentioned previously.